### PR TITLE
fix(ui): remove unwanted hairline under sticky header via border reset + overlay eraser

### DIFF
--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -12,13 +12,26 @@
 
 /* Header is fixed/sticky and layered above content */
 .app-header {
-  position: sticky; 
-  top: 0; 
+  position: sticky;
+  top: 0;
   z-index: 50;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-elev) 95%, transparent), rgba(0, 0, 0, 0.95));
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(8px);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 85%, transparent), var(--surface));
+  border-bottom: 0; /* remove hairline */
+  backdrop-filter: blur(6px);
   box-shadow: 0 6px 24px var(--shadow);
+}
+
+/* Hairline eraser: ensures no background grid/border peeks through */
+.app-header::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--surface);
+  pointer-events: none;
+  z-index: 1;
 }
 
 /* Header content matches your terminal frame */
@@ -126,8 +139,8 @@
   z-index: 0; 
   pointer-events: none;
   background:
-    linear-gradient(to right, color-mix(in srgb, var(--grid) 65%, transparent) 1px, transparent 1px) 0 0/48px 48px,
-    linear-gradient(to bottom, color-mix(in srgb, var(--grid) 65%, transparent) 1px, transparent 1px) 0 0/48px 48px,
+    linear-gradient(to right, color-mix(in srgb, var(--grid) 60%, transparent) 1px, transparent 1px) 0 0/48px 48px,
+    linear-gradient(to bottom, color-mix(in srgb, var(--grid) 60%, transparent) 1px, transparent 1px) 0 0/48px 48px,
     linear-gradient(to right, color-mix(in srgb, var(--grid) 35%, transparent) 1px, transparent 1px) 0 0/12px 12px,
     linear-gradient(to bottom, color-mix(in srgb, var(--grid) 35%, transparent) 1px, transparent 1px) 0 0/12px 12px;
   box-shadow: inset 0 0 160px 40px rgba(0,0,0,.55);

--- a/client/src/styles/voidline-skin.css
+++ b/client/src/styles/voidline-skin.css
@@ -30,8 +30,8 @@ body::before {
   pointer-events: none;
   background:
     /* Grid */
-    linear-gradient(to right, color-mix(in srgb, var(--grid) 65%, transparent) 1px, transparent 1px) 0 0 / 48px 48px,
-    linear-gradient(to bottom, color-mix(in srgb, var(--grid) 65%, transparent) 1px, transparent 1px) 0 0 / 48px 48px,
+    linear-gradient(to right, color-mix(in srgb, var(--grid) 60%, transparent) 1px, transparent 1px) 0 0 / 48px 48px,
+    linear-gradient(to bottom, color-mix(in srgb, var(--grid) 60%, transparent) 1px, transparent 1px) 0 0 / 48px 48px,
     /* Sub-grid */
     linear-gradient(to right, color-mix(in srgb, var(--grid) 35%, transparent) 1px, transparent 1px) 0 0 / 12px 12px,
     linear-gradient(to bottom, color-mix(in srgb, var(--grid) 35%, transparent) 1px, transparent 1px) 0 0 / 12px 12px;
@@ -74,14 +74,8 @@ body::before {
   border-radius: 12px;
 }
 
-/* Header & nav match reference image */
-.site-header, header[data-role=app-header] {
-  position: sticky;
-  top: 0; z-index: 50;
-  background: rgba(0, 0, 0, 0.95);
-  border-bottom: 1px solid #374151;
-  backdrop-filter: blur(8px);
-}
+/* Defensive: guarantee no bottom rule regardless of other imports */
+.site-header, .app-header { border-bottom: 0 !important; }
 .nav-link, [data-role=nav-link] {
   color: #9CA3AF;
   font-family: 'Fira Code', monospace;


### PR DESCRIPTION
## Summary
- remove sticky header border and add pseudo-element "eraser" overlay
- defensively override any bottom borders and soften grid opacity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f79790014832faf6fc8ad4ab303fa