### PR TITLE
fix(ui): header baseline alignment + glassy terminal; add theme token lock to prevent color drift

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="voidline">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -1,135 +1,72 @@
 
-:root {
-  /* sticky heights; adjust only here if header size changes */
-  --header-h: 64px;
+:root{
+  --header-h: 72px;          /* unified header height */
+  --ctl-h: 40px;             /* control height used by nav pills & Login */
 }
-
-@media (min-width: 768px) { 
-  :root { 
-    --header-h: 72px; 
-  } 
+@media (max-width: 768px){
+  :root{ --header-h: 64px; --ctl-h: 36px; }
 }
 
 /* Header is fixed/sticky and layered above content */
-.app-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 85%, transparent), var(--surface));
-  border-bottom: 0; /* remove hairline */
+.app-header{
+  position: sticky; top: 0; z-index: 50;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 85%, transparent), transparent);
+  border-bottom: 0;
   backdrop-filter: blur(6px);
   box-shadow: 0 6px 24px var(--shadow);
 }
 
 /* Hairline eraser: ensures no background grid/border peeks through */
-.app-header::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -1px;
-  height: 2px;
-  background: var(--surface);
-  pointer-events: none;
-  z-index: 1;
+.app-header::after{
+  content:""; position:absolute; left:0; right:0; bottom:-1px; height:2px;
+  background: rgb(var(--surface-rgb) / var(--glass-alpha-header));
+  pointer-events:none; z-index:1;
 }
 
 /* Header content matches your terminal frame */
-.header-inner {
-  max-width: 1200px; 
-  margin: 0 auto;
-  display: grid; 
-  grid-template-columns: 1fr auto auto;
-  align-items: center; 
-  gap: 0.75rem;
-  padding: 0.75rem 1.5rem;
+.header-inner{
+  max-width: 1200px; margin: 0 auto;
+  display: grid; grid-template-columns: 1fr auto auto; gap: .75rem;
+  min-height: var(--header-h);
+  padding-inline: 1rem; padding-block: 8px;
+  align-items: center;  /* vertical centering */
 }
 
 @media (max-width: 768px) {
-  .header-inner {
-    grid-template-columns: 1fr auto;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-  }
-  
-  .nav {
-    display: none;
-  }
+  .header-inner{ grid-template-columns: 1fr auto; }
+  .nav{ display:none; }
 }
 
 /* Brand */
-.brand { 
-  display: inline-flex; 
-  gap: 0.6rem; 
-  align-items: flex-start; 
-  text-decoration: none;
-  transition: opacity 0.2s ease;
-}
-
-.brand:hover {
-  opacity: 0.8;
-}
-
-.sig { 
-  color: var(--accent); 
-  margin-top: 0.2rem;
-  font-family: 'Fira Code', monospace;
-  font-size: 0.875rem;
-}
-
-.brand-title { 
-  color: var(--accent); 
-  font-weight: 700; 
-  letter-spacing: 0.2px;
-  font-family: 'Fira Code', monospace;
-  font-size: 0.875rem;
-  margin: 0;
-}
-
-.brand-sub { 
-  color: var(--muted); 
-  font-size: 0.75rem;
-  font-family: 'Fira Code', monospace;
-  margin: 0;
-}
+.brand{ display:inline-flex; gap:.6rem; align-items:center; text-decoration:none; min-height: var(--ctl-h); }
+.sig{ color: var(--accent); margin-top:.1rem; }
+.brand-copy{ line-height: 1.1; }
+.brand-title{ color:#C8D2DF; font-weight:700; letter-spacing:.2px; }
+.brand-sub{ color:var(--muted); font-size:.72rem; }
 
 /* Nav */
-.nav { 
-  display: inline-flex; 
-  gap: 0.35rem; 
+.nav{ display:none; align-items:center; gap:.35rem; }
+@media (min-width: 768px){ .nav{ display:inline-flex; } }
+.nav-link{
+  color: var(--muted);
+  height: var(--ctl-h); line-height: calc(var(--ctl-h) - 2px);
+  padding: 0 .6rem; border-radius:.6rem;
+  background: rgb(var(--surface-rgb) / .18);
+  display:inline-flex; align-items:center;
+  transition: color .15s ease, background-color .15s ease, box-shadow .15s ease;
 }
-
-.nav-link {
-  color: var(--muted); 
-  padding: 0.35rem 0.5rem; 
-  border-radius: 0.5rem;
-  transition: color 0.15s ease, background-color 0.15s ease;
-  text-decoration: none;
-  font-family: 'Fira Code', monospace;
-  font-size: 0.875rem;
-}
-
-.nav-link:hover, 
-.nav-link[data-active="true"] { 
-  color: var(--accent); 
-  background: color-mix(in srgb, var(--bg-elev) 70%, transparent); 
+.nav-link:hover{ color: var(--text); background: rgb(var(--surface-rgb) / .28); box-shadow: 0 0 0 1px rgb(var(--accent-rgb,63 185 80)/.18); }
+.nav-link[aria-current="page"], .nav-link[data-active="true"]{
+  color:#041b0d;
+  background: linear-gradient(180deg, var(--accent), var(--accent-600));
+  box-shadow: 0 4px 14px rgb(var(--accent-rgb,63 185 80)/.28);
 }
 
 /* Actions */
-.actions { 
-  display: inline-flex; 
-  align-items: center; 
-  gap: 0.75rem; 
-}
+.actions{ display:inline-flex; align-items:center; gap:.6rem; }
 
 /* Main scroll area: fills viewport minus header, scrolls independently */
-.app-main {
-  height: calc(100dvh - var(--header-h));
-  overflow-y: auto; 
-  overscroll-behavior: contain;
-  position: relative;
-  z-index: 1; /* under header */
-}
+.app-main{ height: calc(100dvh - var(--header-h)); overflow-y:auto; overscroll-behavior:contain; position:relative; z-index:1; padding:1rem; }
 
 /* Grid background and vignette pinned to viewport */
 .app-shell::before {
@@ -169,16 +106,18 @@
   transform: translateY(-1px); 
 }
 
-.btn-ghost { 
-  color: var(--accent); 
-  border: 1px solid var(--accent); 
-  background: transparent; 
+.btn-ghost{
+  color:var(--text);
+  height: var(--ctl-h); line-height: calc(var(--ctl-h) - 2px);
+  display:inline-flex; align-items:center; padding: 0 .9rem;
+  border:1px solid color-mix(in srgb, var(--border) 70%, rgb(var(--accent-rgb,63 185 80) / .25));
+  background: rgb(var(--surface-rgb) / .18);
+  box-shadow: inset 0 0 0 1px rgb(var(--accent-rgb,63 185 80)/.16);
+  border-radius: .75rem;
 }
 
-.btn-ghost:hover {
-  background: var(--accent);
-  color: #041b0d;
-}
+/* Glass alpha specific to header container (more transparent) */
+.app-header .terminal-window{ background: rgb(var(--surface-rgb) / var(--glass-alpha-header)); }
 
 /* Header traffic lights */
 .header-lights { 

--- a/client/src/styles/voidline-skin.css
+++ b/client/src/styles/voidline-skin.css
@@ -15,11 +15,25 @@
   --info: #60A5FA;          /* cyan/blue meters */
   --danger: #F87171;        /* alerts */
   --shadow: rgba(0,0,0,.35);
+
+  /* glass */
+  --surface-rgb: 14 20 26;
+  --glass-alpha: .26;
+  --glass-alpha-header: .22;
+  --glass-blur: 10px;
+  --glass-outline: 1px;
+  --glass-accent: 63 185 80;
 }
 
 html, body {
   background-color: var(--bg);
   color: var(--text);
+}
+
+/* Global theme lock — any page uses these tokens */
+:root, [data-theme="voidline"]{
+  --tw-prose-body: var(--text);
+  --tw-prose-headings: var(--text);
 }
 
 /* Background grid with vignette (no layout changes) */
@@ -37,6 +51,23 @@ body::before {
     linear-gradient(to bottom, color-mix(in srgb, var(--grid) 35%, transparent) 1px, transparent 1px) 0 0 / 12px 12px;
   box-shadow: inset 0 0 160px 40px rgba(0,0,0,.55);
   z-index: 0;
+}
+
+/* Glassy surface used by header and cards */
+.terminal-window{
+  background: rgb(var(--surface-rgb) / var(--glass-alpha));
+  -webkit-backdrop-filter: saturate(140%) blur(var(--glass-blur));
+  backdrop-filter: saturate(140%) blur(var(--glass-blur));
+  border-radius:16px;
+  border: 1px solid color-mix(in srgb, rgb(var(--surface-rgb)) 75%, var(--border));
+  box-shadow: 0 2px 12px var(--shadow),
+              inset 0 0 0 var(--glass-outline) rgb(var(--glass-accent) / .18);
+}
+.terminal-window.hoverable:hover{
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0,0,0,.45),
+              inset 0 0 0 var(--glass-outline) rgb(var(--glass-accent) / .28);
+  transition: transform .18s ease, box-shadow .18s ease;
 }
 
 /* Elevation, borders, radii */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ export default {
       colors: {
         // Voidline theme colors from CSS variables
         bg: "var(--bg)",
-        surface: "var(--bg-elev)",
+        surface: "var(--surface)",
         grid: "var(--grid)",
         border: "var(--border)",
         text: "var(--text)",
@@ -27,12 +27,12 @@ export default {
         info: "var(--info)",
         danger: "var(--danger)",
         // Surface colors
-        surface: {
+        surfacePalette: {
           dark: "var(--bg)",
-          darker: "var(--bg-elev)",
+          darker: "var(--surface)",
         },
         // Terminal accent colors
-        accent: {
+        accentPalette: {
           primary: "var(--accent)",
           secondary: "var(--accent-600)",
           matrix: "#00FF41",
@@ -42,7 +42,7 @@ export default {
           cyan: "#17A2B8",
         },
         // Text colors
-        text: {
+        textPalette: {
           primary: "var(--text)",
           secondary: "var(--muted)",
           muted: "var(--muted)",
@@ -66,7 +66,7 @@ export default {
           DEFAULT: "var(--secondary)",
           foreground: "var(--secondary-foreground)",
         },
-        muted: {
+        mutedPalette: {
           DEFAULT: "var(--muted)",
           foreground: "var(--muted-foreground)",
         },
@@ -74,7 +74,7 @@ export default {
           DEFAULT: "var(--destructive)",
           foreground: "var(--destructive-foreground)",
         },
-        border: "var(--border)",
+        borderColor: "var(--border)",
         input: "var(--input)",
         ring: "var(--ring)",
         chart: {
@@ -138,11 +138,12 @@ export default {
         "glow-md": "0 0 20px var(--theme-glow)",
         "glow-lg": "0 0 30px var(--theme-glow-strong)",
         "terminal": "0 4px 20px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(255, 255, 255, 0.1)",
-        "card": "0 2px 12px var(--shadow)",
+        card: "0 2px 12px var(--shadow)",
         "card-hover": "0 8px 24px rgba(0,0,0,.45)",
+        cardHover: "0 8px 24px rgba(0,0,0,.45)",
       },
       backgroundImage: {
-        "voidline-surface": "linear-gradient(180deg, color-mix(in srgb, var(--bg-elev) 88%, transparent), var(--bg-elev))",
+        "voidline-surface": "linear-gradient(180deg, color-mix(in srgb, var(--surface) 88%, transparent), var(--surface))",
       },
       transitionTimingFunction: {
         "void-snap": "cubic-bezier(.2,.6,.2,1)",


### PR DESCRIPTION
## Summary
- align brand, nav pills, and login button on a unified header baseline with sticky glassy style
- lock global palette tokens and glass variables for terminal window surfaces
- extend Tailwind palette and shadows with theme variables

## Testing
- `npm run check` *(fails: Property 'handleStartMasteringSession' does not exist on type 'Window & typeof globalThis' and other TS errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f7df92a1c832f9020e6786078cfe4