### PR TITLE
style: center header and accent upload cta

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -20,9 +20,10 @@ export function AppHeader() {
       role="banner"
       aria-label="Primary"
     >
-      <div className="header-inner terminal-window">
+      {/* NOTE: p-2 stays; CSS centers this block and controls max-width */}
+      <div className="header-inner terminal-window p-2">
         <a href="/" className="brand group" aria-label="Homepage">
-          <span className="sig">[-]</span>
+          <span className="sig">[~]</span>
           <div className="brand-copy">
             <h1 className="brand-title">./C/No_Voidline</h1>
             <p className="brand-sub">Frequencies attained. Stillness remains.</p>

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -1,6 +1,9 @@
 :root{
-  --header-h: 64px;         /* slimmer like the reference */
-  --ctl-h: 34px;            /* pills/login height */
+  --header-h: 64px;    /* slim header */
+  --ctl-h: 34px;       /* pill/login height */
+  --header-max: 1120px;/* center width similar to reference */
+  --brand-sub-size: 0.66rem;  /* ~3× smaller than title */
+  --brand-grey: #9aa9b8;      /* same family as nav grey */
 }
 
 .app-header{
@@ -12,9 +15,12 @@
 }
 
 .header-inner{
-  max-width: 1200px; margin: 0 auto;
-  display: grid; grid-template-columns: 1fr auto auto;
-  gap: .75rem; min-height: var(--header-h);
+  width: clamp(320px, 92vw, var(--header-max));
+  margin-inline: auto;           /* center horizontally */
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: .75rem;
+  min-height: var(--header-h);
   padding: 6px 12px;
   align-items: center;
 }
@@ -41,10 +47,23 @@
 }
 
 /* Brand + baseline rhythm */
-.brand{ display:inline-flex; gap:.6rem; align-items:center; min-height: var(--ctl-h); }
-.sig{ color: var(--accent); margin-top:.1rem; }
-.brand-title{ color:#C8D2DF; font-weight:700; letter-spacing:.2px; }
-.brand-sub{ color:var(--muted); font-size:.72rem; }
+.brand{
+  display:grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto;
+  column-gap:.6rem; align-items:center; min-height: var(--ctl-h);
+}
+.sig{
+  color: var(--accent);           /* KEEP green */
+  grid-row: 1 / span 2;           /* span both rows */
+  align-self: center;             /* center vs title+subtitle */
+}
+.brand-copy{ line-height: 1.05; }
+.brand-title{ color:#C8D2DF; font-weight:700; letter-spacing:.2px; grid-column:2; }
+.brand-sub{
+  color: var(--brand-grey);      /* grey like nav/button chips */
+  font-size: var(--brand-sub-size);
+  grid-column: 2;
+  margin-top: 2px;
+}
 
 /* Nav pills: grey active chip, no press color */
 .nav{ display:none; align-items:center; gap:.35rem; }

--- a/client/src/styles/voidline-skin.css
+++ b/client/src/styles/voidline-skin.css
@@ -148,3 +148,21 @@ body::before {
 @media (prefers-reduced-motion: reduce) {
   * { transition: none !important; animation: none !important; }
 }
+
+/* Accent-green upload CTA */
+.upload-cta,
+.dropzone button,
+.dropzone [role="button"] {
+  border: 1px solid rgba(63,185,80,.45);
+  color: #0b1a10;
+  background: linear-gradient(180deg, var(--accent), var(--accent-600));
+  border-radius: 10px;
+  padding: .6rem .9rem;
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(63,185,80,.25);
+}
+.upload-cta:hover,
+.dropzone button:hover,
+.dropzone [role="button"]:hover {
+  filter: brightness(1.05);
+}


### PR DESCRIPTION
## Summary
- center terminal window header and align brand grid
- shrink brand subtitle and apply grey styling
- style upload CTA with green accent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f8b25c7f8832f9e6a68f4974806df