### PR TITLE
feat: scaffold phase 1 visual deck

### DIFF
--- a/client/src/components/mastering/phase1/DynamicsPanel.tsx
+++ b/client/src/components/mastering/phase1/DynamicsPanel.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { attachHiDPICanvas } from '@/lib/vis/canvasKit';
+
+interface PanelProps {
+  className?: string;
+}
+
+export function DynamicsPanel({ className }: PanelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return attachHiDPICanvas(canvas, (ctx) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#f90';
+      ctx.fillRect(10, canvas.height - 30, 20, 20);
+    });
+  }, []);
+
+  return (
+    <article className={className}>
+      <div className="card__hd">Dynamics</div>
+      <div className="card__bd visual small">
+        <canvas ref={canvasRef} />
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/mastering/phase1/FrequenciesPanel.tsx
+++ b/client/src/components/mastering/phase1/FrequenciesPanel.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { attachHiDPICanvas } from '@/lib/vis/canvasKit';
+
+interface PanelProps {
+  className?: string;
+}
+
+export function FrequenciesPanel({ className }: PanelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return attachHiDPICanvas(canvas, (ctx) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = '#0ff';
+      ctx.beginPath();
+      ctx.moveTo(0, canvas.height / 2);
+      ctx.lineTo(canvas.width, canvas.height / 2);
+      ctx.stroke();
+    });
+  }, []);
+
+  return (
+    <article className={className}>
+      <div className="card__hd">Frequencies</div>
+      <div className="card__bd visual tall">
+        <canvas ref={canvasRef} />
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/mastering/phase1/NuancePanel.tsx
+++ b/client/src/components/mastering/phase1/NuancePanel.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { attachHiDPICanvas } from '@/lib/vis/canvasKit';
+
+interface PanelProps {
+  className?: string;
+}
+
+export function NuancePanel({ className }: PanelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return attachHiDPICanvas(canvas, (ctx) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0f0';
+      ctx.fillRect(10, 10, 20, 20);
+    });
+  }, []);
+
+  return (
+    <article className={className}>
+      <div className="card__hd">Nuance</div>
+      <div className="card__bd visual small">
+        <canvas ref={canvasRef} />
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/mastering/phase1/Phase1VisualDeck.tsx
+++ b/client/src/components/mastering/phase1/Phase1VisualDeck.tsx
@@ -1,0 +1,19 @@
+import { NuancePanel } from './NuancePanel';
+import { DynamicsPanel } from './DynamicsPanel';
+import { FrequenciesPanel } from './FrequenciesPanel';
+import { StereoImagePanel } from './StereoImagePanel';
+
+export function Phase1VisualDeck({ sessionId }: { sessionId: string }) {
+  return (
+    <section
+      className="auto-grid dense"
+      style={{ ['--card-min' as any]: '340px' }}
+      data-session={sessionId}
+    >
+      <NuancePanel className="terminal-window card hoverable" />
+      <DynamicsPanel className="terminal-window card hoverable" />
+      <FrequenciesPanel className="terminal-window card hoverable" />
+      <StereoImagePanel className="terminal-window card hoverable" />
+    </section>
+  );
+}

--- a/client/src/components/mastering/phase1/StereoImagePanel.tsx
+++ b/client/src/components/mastering/phase1/StereoImagePanel.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { attachHiDPICanvas } from '@/lib/vis/canvasKit';
+
+interface PanelProps {
+  className?: string;
+}
+
+export function StereoImagePanel({ className }: PanelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return attachHiDPICanvas(canvas, (ctx) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#ccc';
+      ctx.beginPath();
+      ctx.arc(canvas.width / 2, canvas.height / 2, 30, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  }, []);
+
+  return (
+    <article className={className}>
+      <div className="card__hd">Stereo Image</div>
+      <div className="card__bd visual">
+        <canvas ref={canvasRef} />
+      </div>
+    </article>
+  );
+}

--- a/client/src/lib/vis/canvasKit.ts
+++ b/client/src/lib/vis/canvasKit.ts
@@ -1,0 +1,44 @@
+export function attachHiDPICanvas(
+  canvas: HTMLCanvasElement,
+  onResize?: (ctx: CanvasRenderingContext2D) => void
+) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return () => {};
+
+  const resize = () => {
+    const dpr = window.devicePixelRatio || 1;
+    const { width, height } = canvas.getBoundingClientRect();
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.resetTransform();
+    ctx.scale(dpr, dpr);
+    onResize?.(ctx);
+  };
+
+  resize();
+  const ro = new ResizeObserver(resize);
+  ro.observe(canvas);
+  return () => ro.disconnect();
+}
+
+export function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+export class RingBuffer<T> {
+  private buf: T[];
+  private idx = 0;
+
+  constructor(private size: number, fill: T) {
+    this.buf = Array(size).fill(fill);
+  }
+
+  push(v: T) {
+    this.buf[this.idx] = v;
+    this.idx = (this.idx + 1) % this.size;
+  }
+
+  values() {
+    return [...this.buf.slice(this.idx), ...this.buf.slice(0, this.idx)];
+  }
+}

--- a/client/src/lib/vis/interactions.ts
+++ b/client/src/lib/vis/interactions.ts
@@ -1,0 +1,31 @@
+export interface ViewTransform {
+  xZoom: number;
+  xOffset: number;
+  yZoom: number;
+  yOffset: number;
+}
+
+export const defaultTransform: ViewTransform = {
+  xZoom: 1,
+  xOffset: 0,
+  yZoom: 1,
+  yOffset: 0,
+};
+
+export function registerInteractions(
+  el: HTMLElement,
+  transform: ViewTransform,
+  onTransform: (t: ViewTransform) => void
+) {
+  const handleDbl = () => {
+    onTransform({ ...defaultTransform });
+  };
+  el.addEventListener('dblclick', handleDbl);
+  return () => {
+    el.removeEventListener('dblclick', handleDbl);
+  };
+}
+
+export function hoverAt(x: number, y: number) {
+  return { x, y };
+}

--- a/client/src/pages/MasteringProcess.tsx
+++ b/client/src/pages/MasteringProcess.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { AppShell } from '@/components/layout/AppShell';
 import { Phase1DeepSignal } from '@/components/mastering/Phase1DeepSignal';
 import Phase2Reconstruction from '@/components/mastering/Phase2Reconstruction';
+import { Phase1VisualDeck } from '@/components/mastering/phase1/Phase1VisualDeck';
 import { useMasteringStore } from '@/state/masteringStore';
 
 /**
@@ -40,8 +41,11 @@ export default function MasteringProcess() {
           </p>
         </div>
         
-        {/* Phase 1: Deep Signal Deconstruction */}
-        <Phase1DeepSignal />
+          {/* Phase 1: Deep Signal Deconstruction */}
+          <Phase1DeepSignal />
+          <div className="mt-6">
+            <Phase1VisualDeck sessionId={sessionId} />
+          </div>
         
         {/* Phase 2: Intelligent Reconstruction */}
         <div className="mt-8">

--- a/client/src/state/phase1VisStore.ts
+++ b/client/src/state/phase1VisStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { ViewTransform, defaultTransform } from '@/lib/vis/interactions';
+
+interface Phase1VisState {
+  freeze: boolean;
+  transforms: Record<string, ViewTransform>;
+  setTransform: (panel: string, tx: Partial<ViewTransform>) => void;
+  toggleFreeze: () => void;
+}
+
+export const usePhase1VisStore = create<Phase1VisState>((set) => ({
+  freeze: false,
+  transforms: {
+    nuance: { ...defaultTransform },
+    dynamics: { ...defaultTransform },
+    frequencies: { ...defaultTransform },
+    stereo: { ...defaultTransform },
+  },
+  setTransform: (panel, tx) =>
+    set((state) => ({
+      transforms: {
+        ...state.transforms,
+        [panel]: { ...state.transforms[panel], ...tx },
+      },
+    })),
+  toggleFreeze: () => set((s) => ({ freeze: !s.freeze })),
+}));

--- a/client/src/styles/responsive-grid.css
+++ b/client/src/styles/responsive-grid.css
@@ -29,9 +29,9 @@ img, canvas, svg, video { max-width: 100%; height: auto; display: block; }
 .card__ft { padding: .75rem 1rem; border-top: 1px solid var(--border); }
 
 /* Live visual containers reserve space (no layout shift) */
-.visual { position: relative; height: var(--visual-h, 240px); }
-.visual.is-small { --visual-h: 160px; }
-.visual.is-tall  { --visual-h: 320px; }
+.visual { position: relative; height: var(--visual-h, 260px); }
+.visual.small { --visual-h: 180px; }
+.visual.tall  { --visual-h: 320px; }
 
 /* Canvas fills container; high-DPI controlled via JS ResizeObserver */
 .visual > canvas, .visual > svg { position:absolute; inset:0; width:100%; height:100%; }

--- a/client/worklets/correlation-processor.js
+++ b/client/worklets/correlation-processor.js
@@ -1,0 +1,25 @@
+class CorrelationProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._last = 0;
+  }
+  process(inputs) {
+    const left = inputs[0] && inputs[0][0] ? inputs[0][0] : [];
+    const right = inputs[0] && inputs[0][1] ? inputs[0][1] : [];
+    let corr = 0;
+    const len = Math.min(left.length, right.length);
+    for (let i = 0; i < len; i++) corr += left[i] * right[i];
+    corr = len ? corr / len : 0;
+    if (currentTime - this._last > 0.1) {
+      this.port.postMessage({
+        corr,
+        mid_dB: 0,
+        side_dB: 0,
+        scope: new Float32Array(),
+      });
+      this._last = currentTime;
+    }
+    return true;
+  }
+}
+registerProcessor('correlation-processor', CorrelationProcessor);

--- a/client/worklets/microdynamics-processor.js
+++ b/client/worklets/microdynamics-processor.js
@@ -1,0 +1,25 @@
+class MicroDynamicsProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._last = 0;
+  }
+  process(inputs) {
+    const input = inputs[0];
+    const channel = input && input[0] ? input[0] : [];
+    let sum = 0;
+    for (let i = 0; i < channel.length; i++) sum += channel[i] * channel[i];
+    const rms = channel.length ? Math.sqrt(sum / channel.length) : 0;
+    if (currentTime - this._last > 0.1) {
+      this.port.postMessage({
+        rmsFast_dB: rms ? 20 * Math.log10(rms) : -Infinity,
+        rmsSlow_dB: rms ? 20 * Math.log10(rms) : -Infinity,
+        deltaRMS_dB: 0,
+        crest_dB: 0,
+        transientsPerSec: 0,
+      });
+      this._last = currentTime;
+    }
+    return true;
+  }
+}
+registerProcessor('microdynamics-processor', MicroDynamicsProcessor);

--- a/client/worklets/spectrum-processor.js
+++ b/client/worklets/spectrum-processor.js
@@ -1,0 +1,20 @@
+class SpectrumProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._last = 0;
+  }
+  process(inputs) {
+    const input = inputs[0] && inputs[0][0] ? inputs[0][0] : [];
+    const bins = new Float32Array(32);
+    if (currentTime - this._last > 0.1) {
+      this.port.postMessage({
+        bars_dB: bins,
+        smooth_dB: bins,
+        freqs_Hz: bins,
+      });
+      this._last = currentTime;
+    }
+    return true;
+  }
+}
+registerProcessor('spectrum-processor', SpectrumProcessor);


### PR DESCRIPTION
## Summary
- scaffold Phase1VisualDeck with Nuance, Dynamics, Frequencies, and Stereo Image panels
- add canvas utilities, interaction hooks, and Zustand store for panel transforms
- introduce stub audio worklets and responsive CSS for visual containers
- mount Phase1VisualDeck on the MasteringProcess page

## Testing
- `npm run check` *(fails: preset.usageCount possibly null, compareMetrics implicit any, engineGraph property missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689fb345933c832f94e25423338384de