### PR TITLE
docs: add build audit

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,15 +1,17 @@
 # Build Audit
 
-## Tool Versions
-- Node.js 20.19.4
-- npm 11.4.2
-- Vite 5.4.19
-- TypeScript 5.6.3
-- ESLint 9.33.0
+## Detected Versions
+- Node: v20.19.4
+- npm: 11.4.2
+- Vite: 5.4.19
+- TypeScript: 5.6.3
+- React: 18.3.1
 
-## Issues
-- `npm run quick-start` requires Docker and fails when Docker is unavailable.
-- TypeScript check reports numerous errors, primarily in audio processors and visualization modules.
-- No `test` script configured; `npm test` fails.
-- Build succeeds with warnings about large chunks and mixed static/dynamic imports.
+## Problems
+- `npm run dev` fails without `DATABASE_URL` and `REPLIT_DOMAINS` env variables.
+- `npm run check` reports multiple TypeScript errors across audio engine and visualizer files.
+- `npm test` missing: no test script defined.
+- Build emits chunk-size and dynamic import warnings.
 
+## Performance Notes
+- No runtime profiling performed; potential performance traps remain unassessed.


### PR DESCRIPTION
## Summary
- add build audit with tooling versions and known issues

## Testing
- `npm install`
- `npm run setup`
- `DATABASE_URL=postgresql://localhost/test REPLIT_DOMAINS=localhost npm run dev`
- `npm run build`
- `npm run deploy -- static`
- `npm run check` *(fails: TypeScript errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a049fb58fc832fb101a21806b2d73e