### PR TITLE
fix: stabilize slider and mastering layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { AppShell } from "@/components/layout/AppShell";
+import { AppErrorBoundary } from "@/components/AppErrorBoundary";
 import { useAuth } from "@/hooks/useAuth";
 import Landing from "@/pages/Landing";
 import Console from "@/pages/Console";
@@ -58,7 +59,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <TooltipProvider>
-          <Router />
+          <AppErrorBoundary>
+            <Router />
+          </AppErrorBoundary>
           <Toaster />
         </TooltipProvider>
       </ThemeProvider>

--- a/client/src/components/AppErrorBoundary.tsx
+++ b/client/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export class AppErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: any }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    return { error };
+  }
+
+  componentDidCatch(err: any, info: any) {
+    // log if needed
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="p-4 border border-red-500 rounded">
+          <h2 className="text-red-400 font-semibold">Something broke in this panel.</h2>
+          <pre className="text-xs opacity-80 overflow-auto max-h-64">
+            {String(this.state.error?.stack || this.state.error)}
+          </pre>
+        </div>
+      );
+    }
+    return this.props.children as any;
+  }
+}

--- a/client/src/components/controls/Fader.tsx
+++ b/client/src/components/controls/Fader.tsx
@@ -28,8 +28,8 @@ export function Fader({
   const [isHovered, setIsHovered] = useState(false);
 
   const handleValueChange = useCallback(
-    (newValue: number[]) => {
-      onChange(newValue[0]);
+    (v: number) => {
+      onChange(v);
     },
     [onChange]
   );
@@ -84,7 +84,7 @@ export function Fader({
           onMouseLeave={() => setIsHovered(false)}
         >
           <Slider
-            value={[value]}
+            value={value}
             onValueChange={handleValueChange}
             min={min}
             max={max}

--- a/client/src/components/ui/__tests__/slider.loop.spec.tsx
+++ b/client/src/components/ui/__tests__/slider.loop.spec.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { Slider } from '../slider';
+
+// Polyfill ResizeObserver for jsdom
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
+
+function Controlled() {
+  const [value, setValue] = React.useState(0);
+  return <Slider value={value} onValueChange={setValue} min={0} max={100} step={1} />;
+}
+
+describe('Slider loop prevention', () => {
+  it('does not trigger recursive updates', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Controlled />);
+    const slider = screen.getByRole('slider');
+    await userEvent.keyboard('{ArrowRight}');
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/client/src/components/ui/slider.tsx
+++ b/client/src/components/ui/slider.tsx
@@ -1,26 +1,64 @@
-import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
+
+interface SliderProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>,
+    "value" | "defaultValue" | "onValueChange" | "onValueCommit"
+  > {
+  value: number;
+  onValueChange?: (value: number) => void;
+  onValueCommit?: (value: number) => void;
+}
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
-Slider.displayName = SliderPrimitive.Root.displayName
+  SliderProps
+>(({ className, value, onValueChange, onValueCommit, ...props }, ref) => {
+  const arr = React.useMemo(() => [value], [value]);
+  const last = React.useRef<number>(value);
 
-export { Slider }
+  const handleChange = React.useCallback(
+    (vals: number[]) => {
+      const v = vals[0];
+      if (Object.is(v, last.current)) return;
+      last.current = v;
+      onValueChange?.(v);
+    },
+    [onValueChange]
+  );
+
+  const handleCommit = React.useCallback(
+    (vals: number[]) => {
+      const v = vals[0];
+      if (Object.is(v, last.current)) return;
+      last.current = v;
+      onValueCommit?.(v);
+    },
+    [onValueCommit]
+  );
+
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      value={arr}
+      onValueChange={handleChange}
+      onValueCommit={handleCommit}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  );
+});
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/client/src/pages/MasteringProcess.tsx
+++ b/client/src/pages/MasteringProcess.tsx
@@ -4,6 +4,7 @@ import { AppShell } from '@/components/layout/AppShell';
 import { Phase1DeepSignal } from '@/components/mastering/Phase1DeepSignal';
 import Phase2Reconstruction from '@/components/mastering/Phase2Reconstruction';
 import { Phase1VisualDeck } from '@/components/mastering/phase1/Phase1VisualDeck';
+import { ExportPanelMock } from '@/components/ExportPanelMock';
 import { useMasteringStore } from '@/state/masteringStore';
 
 /**
@@ -11,7 +12,11 @@ import { useMasteringStore } from '@/state/masteringStore';
  * Uses AppShell for exact header parity with main page
  */
 export default function MasteringProcess() {
-  const { currentSession, createSession } = useMasteringStore();
+  const currentSession = useMasteringStore(s => s.currentSession);
+  const createSession = useMasteringStore(s => s.createSession);
+  const currentPhase = useMasteringStore(s => s.currentSession?.currentPhase);
+  const phase1Done =
+    currentPhase === 'phase2' || currentPhase === 'phase3' || currentPhase === 'complete';
   const [location] = useLocation();
   
   // Extract session ID from URL or use current session
@@ -41,16 +46,29 @@ export default function MasteringProcess() {
           </p>
         </div>
         
+        <section id="phase-1" className="space-y-4">
           {/* Phase 1: Deep Signal Deconstruction */}
           <Phase1DeepSignal />
           <div className="mt-6">
             <Phase1VisualDeck sessionId={sessionId} />
           </div>
-        
-        {/* Phase 2: Intelligent Reconstruction */}
-        <div className="mt-8">
-          <Phase2Reconstruction sessionId={sessionId} />
-        </div>
+        </section>
+
+        {phase1Done && (
+          <>
+            <div className="mt-8 text-center font-mono text-accent-primary">
+              Phase 1: Deep Signal Deconstruction Complete
+            </div>
+
+            <section id="phase-2" className="mt-8 space-y-4">
+              <Phase2Reconstruction sessionId={sessionId} />
+            </section>
+
+            <section id="phase-3" className="mt-8 space-y-4">
+              <ExportPanelMock />
+            </section>
+          </>
+        )}
       </div>
     </AppShell>
   );

--- a/client/src/pages/__tests__/mastering.layout.spec.tsx
+++ b/client/src/pages/__tests__/mastering.layout.spec.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import MasteringProcess from '../MasteringProcess';
+import { useMasteringStore, MasteringSession } from '@/state/masteringStore';
+
+vi.mock('@/components/mastering/Phase1DeepSignal', () => ({
+  Phase1DeepSignal: () => <div>Phase1</div>,
+}));
+vi.mock('@/components/mastering/phase1/Phase1VisualDeck', () => ({
+  Phase1VisualDeck: () => <div>Deck</div>,
+}));
+vi.mock('@/components/mastering/Phase2Reconstruction', () => ({
+  default: () => <div>Phase2</div>,
+}));
+vi.mock('@/components/ExportPanelMock', () => ({
+  ExportPanelMock: () => <div>Export</div>,
+}));
+vi.mock('@/components/layout/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const baseSession: MasteringSession = {
+  id: '1',
+  fileMeta: { name: 'test', duration: 0, sr: 44100, channels: 2 },
+  buffer: null,
+  analysis: null,
+  audioMetrics: null,
+  currentPhase: 'phase1',
+  settings: { fftSize: 2048, smoothing: 0.8, corridor: 'streaming', scopeMode: 'polar' },
+};
+
+describe('MasteringProcess layout', () => {
+  beforeEach(() => {
+    useMasteringStore.setState({ currentSession: baseSession });
+  });
+
+  it('hides Phase-2 and Phase-3 when Phase-1 incomplete', () => {
+    render(<MasteringProcess />);
+    expect(document.querySelector('#phase-2')).toBeNull();
+    expect(document.querySelector('#phase-3')).toBeNull();
+  });
+
+  it('shows Phase-2 and Phase-3 after Phase-1 complete', () => {
+    useMasteringStore.setState({ currentSession: { ...baseSession, currentPhase: 'phase2' } });
+    render(<MasteringProcess />);
+    expect(document.querySelector('#phase-2')).not.toBeNull();
+    expect(document.querySelector('#phase-3')).not.toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "drizzle-kit push",
     "setup": "bash ./scripts/setup.sh",
     "quick-start": "bash ./scripts/quick-start.sh",
-    "deploy": "bash ./scripts/deploy.sh"
+    "deploy": "bash ./scripts/deploy.sh",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",


### PR DESCRIPTION
## Summary
- control Radix slider with memoized array and guarded handlers
- guard phase transitions and render Phase-2/3 after Phase-1
- add AppErrorBoundary and regression tests

## Testing
- `npm test --silent`
- `npm run build`
- `npm run dev -- --port 5173` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68a074cea7f4832f8a70c691d48d717f