### PR TITLE
feat: switch phase2 monitoring to processed preview source

### DIFF
--- a/client/src/audio/AudioEngine.ts
+++ b/client/src/audio/AudioEngine.ts
@@ -1,4 +1,4 @@
-import { useSessionStore } from '@/state/useSessionStore';
+import { useSessionStore, AudioMetrics } from '@/state/useSessionStore';
 
 export interface AudioEngineConfig {
   bufferSize: number;
@@ -502,6 +502,17 @@ export class AudioEngine {
         });
       }
     }
+  }
+
+  async prepareProcessedPreview(params: ProcessorParams): Promise<{ snapshot: { metrics: AudioMetrics; fft: Float32Array } }> {
+    this.updateProcessorParams(params);
+    const state = useSessionStore.getState();
+    return {
+      snapshot: {
+        metrics: state.metricsB,
+        fft: state.fftB ? new Float32Array(state.fftB) : new Float32Array(),
+      },
+    };
   }
   
   onUpdate(callback: (deltaTime: number) => void): void {

--- a/client/tests/engine/frame.route.spec.ts
+++ b/client/tests/engine/frame.route.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore, initialMetrics } from '@/state/useSessionStore';
+
+const metricsPre = { ...initialMetrics, peak: 0.5 };
+const metricsPost = { ...initialMetrics, peak: 1.0 };
+const fftPre = new Float32Array([1, 2]);
+const fftPost = new Float32Array([3, 4]);
+
+describe('pushFrameFromEngine routing', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      metricsA: { ...initialMetrics },
+      metricsB: { ...initialMetrics },
+      fftA: null,
+      fftB: null,
+      processedReady: false,
+    });
+  });
+
+  it('routes frames and flags processed readiness', () => {
+    useSessionStore.getState().pushFrameFromEngine({ src: 'pre', metrics: metricsPre, fft: fftPre });
+    expect(useSessionStore.getState().metricsA).toEqual(metricsPre);
+    expect(useSessionStore.getState().fftA).toEqual(fftPre);
+    expect(useSessionStore.getState().processedReady).toBe(false);
+
+    useSessionStore.getState().pushFrameFromEngine({ src: 'post', metrics: metricsPost, fft: fftPost });
+    expect(useSessionStore.getState().metricsB).toEqual(metricsPost);
+    expect(useSessionStore.getState().fftB).toEqual(fftPost);
+    expect(useSessionStore.getState().processedReady).toBe(true);
+  });
+});

--- a/client/tests/pages/phase2.source.spec.tsx
+++ b/client/tests/pages/phase2.source.spec.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { useSessionStore, initialMetrics } from '@/state/useSessionStore';
+
+function PeakLabel() {
+  const peak = useSessionStore(s =>
+    s.phase2Source === 'post' ? s.metricsB.peak : s.metricsA.peak
+  );
+  return <div data-testid="peak">{peak}</div>;
+}
+
+describe('phase2 source switching', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      phase2Source: 'pre',
+      processedReady: false,
+      metricsA: { ...initialMetrics, peak: 1 },
+      metricsB: { ...initialMetrics, peak: 2 },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('reads processed metrics after activation', () => {
+    render(<PeakLabel />);
+    expect(screen.getByTestId('peak').textContent).toBe('1');
+    const snap = { metrics: useSessionStore.getState().metricsB, fft: new Float32Array() };
+    act(() => {
+      useSessionStore.getState().activateProcessedPreview(snap);
+      useSessionStore.getState().setPhase2Source('post');
+    });
+    expect(screen.getByTestId('peak').textContent).toBe('2');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "drizzle-kit push",
     "setup": "bash ./scripts/setup.sh",
     "quick-start": "bash ./scripts/quick-start.sh",
-    "deploy": "bash ./scripts/deploy.sh"
+    "deploy": "bash ./scripts/deploy.sh",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",


### PR DESCRIPTION
## Summary
- add processed phase2 preview state and frame routing helpers
- expose engine API to prepare processed preview snapshots
- cover store routing and source switching with vitest

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a3048e60832faa538c3a9dcfbb6a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Preview processed audio without affecting playback, returning current metrics and spectrum.
  - Switch between pre- and post-processing sources for real-time metrics/FFT views.
  - Processed data readiness indicator improves UX when previews are available.
- Tests
  - Added tests for routing engine frames and verifying processed readiness.
  - Added UI tests for switching sources and reflecting correct metrics.
- Chores
  - Added a test script to run the test suite via the package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->