### PR TITLE
chore: change default dev port to 5001

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "PORT=5001 NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
## Summary
- default `npm run dev` to port 5001 to avoid collision with existing service

## Testing
- `npm test` *(fails: Multiple exports with the same name in AudioEngine.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68a0e1cfdf30832fb42c54703086e5a0